### PR TITLE
update to 1.3.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,10 +38,12 @@ test:
     - pytest -vv --pyargs cerberus.tests
 
 about:
-  home: https://github.com/nicolaiarocci/cerberus
+  home: https://github.com/pyeve/cerberus
   license: ISC
   license_file: LICENSE
   summary: 'Lightweight, extensible schema and data validation tool for Python dictionaries.'
+  dev_url: https://github.com/pyeve/cerberus
+  doc_url: https://docs.python-cerberus.org/en/stable/
 
 extra:
     recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "Cerberus" %}
-{% set version = "1.3.2" %}
-{% set sha256 = "302e6694f206dd85cb63f13fd5025b31ab6d38c99c50c6d769f8fa0b0f299589" %}
+{% set version = "1.3.4" %}
+{% set sha256 = "d1b21b3954b2498d9a79edf16b3170a3ac1021df88d197dc2ce5928ba519237c" %}
 
 package:
   name: {{ name|lower }}
@@ -21,18 +21,21 @@ requirements:
     - pip
     - python
     - setuptools
+    - wheel
 
   run:
     - python
 
 test:
   requires:
+    - pip
     - pytest
   imports:
     - cerberus
     - cerberus.tests
   commands:
-    - pytest --pyargs cerberus
+    - pip check
+    - pytest -vv --pyargs cerberus.tests
 
 about:
   home: https://github.com/nicolaiarocci/cerberus


### PR DESCRIPTION
This is a new feedstock. This PR is to update to 1.3.4 from the 1.3.2 conda forge recipe (which wasn't tested).

Cerberus is a lightweight and extensible data validation library for Python.

* [x] upstream repo https://github.com/pyeve/cerberus
* [x] run tests on dependent packages - none because this is a new feedstock
* [x] go through [changelog](https://github.com/pyeve/cerberus/blob/master/CHANGES.rst)
* [x] look for any open issues for new versions
* [x] dev_url, doc_url valid
* [x] setuptools/wheel/pip/pip check included
* [x] compare pinned versions from upstream